### PR TITLE
Adiciona JPA para H2 nos properties

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,8 @@
+spring.application.name=cohive
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.format_sql=true
+spring.h2.console.enabled=true
+spring.datasource.url=jdbc:h2:mem:cohive
 
+server.error.include-message=always
+server.error.include-binding-errors=always


### PR DESCRIPTION
## Objetivo
Adicionar banco temporário H2

## Implementação
```Java
spring.application.name=cohive
spring.jpa.show-sql=true
spring.jpa.properties.hibernate.format_sql=true
spring.h2.console.enabled=true
spring.datasource.url=jdbc:h2:mem:cohive

server.error.include-message=always
server.error.include-binding-errors=always
```

## TO-DO
- [x] Adicionei a configuração Spring nos `resources/application.properties`