### PR TITLE
Adiciona dependência para o Swagger (OpenAPI)

### DIFF
--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="ProjectModuleManager">
-    <modules>
-      <module fileurl="file://$PROJECT_DIR$/cohive.iml" filepath="$PROJECT_DIR$/cohive.iml" />
-    </modules>
-  </component>
-</project>

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,12 @@
 	</properties>
 	<dependencies>
 		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+			<version>2.5.0</version>
+		</dependency>
+
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,15 @@
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
 
+		<!-- https://mvnrepository.com/artifact/org.springdoc/springdoc-openapi-starter-webmvc-ui -->
+		<!--http://localhost:8080/swagger-ui/index.html#/ -->
+		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+			<version>2.5.0</version>
+		</dependency>
+
+
 		<dependency>
 			<groupId>com.h2database</groupId>
 			<artifactId>h2</artifactId>

--- a/src/main/java/backend/cohive/Observer/Alerta.java
+++ b/src/main/java/backend/cohive/Observer/Alerta.java
@@ -1,4 +1,4 @@
-package backend.cohive.Abstract;
+package backend.cohive.Observer;
 
 import java.time.LocalDateTime;
 

--- a/src/main/java/backend/cohive/Observer/AlertaEstoqueBaixo.java
+++ b/src/main/java/backend/cohive/Observer/AlertaEstoqueBaixo.java
@@ -1,10 +1,9 @@
-package backend.cohive.Abstract;
+package backend.cohive.Observer;
 
-import backend.cohive.ControleEstoque;
+import  backend.cohive.ControleEstoque;
 import backend.cohive.Entidades.Produto;
 
 import java.time.LocalDateTime;
-import java.util.List;
 
 public class AlertaEstoqueBaixo extends Alerta {
 

--- a/src/main/java/backend/cohive/Observer/AlertaEstoqueZerado.java
+++ b/src/main/java/backend/cohive/Observer/AlertaEstoqueZerado.java
@@ -1,4 +1,4 @@
-package backend.cohive.Abstract;
+package backend.cohive.Observer;
 
 import backend.cohive.ControleEstoque;
 import backend.cohive.Entidades.Produto;


### PR DESCRIPTION
## Objetivo
Adicionar a dependência Swagger para documentar API inicial

## Implementação
```Java
		<dependency>
			<groupId>org.springdoc</groupId>
			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
			<version>2.5.0</version>
		</dependency>
```

## TO-DO
- [x] Adicionar dependência Swagger
- [x] Criar controller para Swagger de usuário
- [x] Criar controller para Swagger de estoque
- [x] Criar controller para Swagger de produto